### PR TITLE
some clean up

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,11 +43,8 @@ Kthulhu.prototype._transform = function (chunk, encoding, next) {
 
   var push = function (value) {
     next(null, value)
-  }.bind(this)
+  };
 
-  if (result instanceof Promise) {
-    result.then(push, null)
-  } else {
-    push(result)
-  }
+
+  Promise.resolve(result).then(push, next);
 }

--- a/index.js
+++ b/index.js
@@ -43,8 +43,8 @@ Kthulhu.prototype._transform = function (chunk, encoding, next) {
 
   var push = function (value) {
     next(null, value)
-  };
+  }
 
 
-  Promise.resolve(result).then(push, next);
+  Promise.resolve(result).then(push, next)
 }


### PR DESCRIPTION
2 fixes

1. remove unnecessary bind, as bind can be pretty slow so don't use it when we don't need to
2. don't rely on a promise necessarily being an instance of Promise so people can return promises from other libraries. 